### PR TITLE
Ci: fix build info didn't write

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,8 @@ before:
 builds:
 -
   ldflags:
-    - -s -w -X rod-mcp/banner.Version={{ .Version }}
-    - -X rod-mcp/banner.BuildTime={{ .Date }}
+    - -s -w -X github.com/go-rod/rod-mcp/banner.Version={{ .Version }}
+    - -X github.com/go-rod/rod-mcp/banner.BuildTime={{ .Date }}
   env:
     - CGO_ENABLED=0
   goos:


### PR DESCRIPTION
- Update the import path for rod-mcp/banner to use the full URL
- This change ensures correct version and build time information