### PR TITLE
feat(config): add CDP endpoint support for external browser control

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -10,9 +10,10 @@ import (
 )
 
 type SubCfg struct {
-	Headless   bool
-	ConfigPath string
-	Mode       types.Mode
+	Headless    bool
+	ConfigPath  string
+	Mode        types.Mode
+	CDPEndpoint string
 }
 
 func RunCmd() (*SubCfg, error) {
@@ -28,6 +29,11 @@ func RunCmd() (*SubCfg, error) {
 				Aliases:     []string{"c"},
 				Usage:       "use to set Rod MCP Server's config file path, file name is `rod-mcp.yaml`",
 				Destination: &subConfig.ConfigPath,
+			}, &cli.StringFlag{
+				Name:        "cdp-endpoint",
+				Aliases:     []string{"c"},
+				Usage:       "use to control running browser by cdp",
+				Destination: &subConfig.CDPEndpoint,
 			},
 			&cli.BoolFlag{
 				Name:        "headless",

--- a/main.go
+++ b/main.go
@@ -29,8 +29,13 @@ func main() {
 	if subCfg.Headless {
 		cfg.Headless = true
 	}
+
 	if subCfg.Mode != "" {
 		cfg.Mode = subCfg.Mode
+	}
+
+	if subCfg.CDPEndpoint != "" {
+		cfg.CDPEndpoint = subCfg.CDPEndpoint
 	}
 
 	runner := NewRunner(ctx, *cfg)

--- a/types/config.go
+++ b/types/config.go
@@ -13,6 +13,7 @@ const ConfigName = "rod-mcp.yaml"
 
 type Config struct {
 	Mode           Mode         `yaml:"mode" json:"mode"`
+	CDPEndpoint    string       `yaml:"cdpEndpoint" json:"cdpEndpoint"`
 	ServerName     string       `yaml:"serverName" json:"serverName"`
 	ServerVersion  string       `yaml:"-" json:"-"`
 	BrowserBinPath string       `yaml:"browserBinPath" json:"browserBinPath"`


### PR DESCRIPTION
- Add CDPEndpoint field to SubCfg and Config structs
- Implement controlBrowser function to connect to external browser via CDP
- Update launchBrowser to use controlBrowser for both local and external browsers
- Add option to remove browser temp dir when using external browser
- Update CLI flags and configuration parsing to include CDP endpoint