### PR TITLE
Use valid MPC version

### DIFF
--- a/server.go
+++ b/server.go
@@ -9,6 +9,8 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+const VERSION = "1.0.0"
+
 type Server struct {
 	ctx       *types.Context
 	mcpServer *server.MCPServer
@@ -16,7 +18,7 @@ type Server struct {
 
 func NewServer(stdCtx context.Context, cfg types.Config) *Server {
 	ctx := types.NewContext(stdCtx, cfg)
-	mcpServer := server.NewMCPServer(cfg.ServerName, cfg.ServerVersion)
+	mcpServer := server.NewMCPServer(cfg.ServerName, VERSION)
 	ser := &Server{
 		ctx:       ctx,
 		mcpServer: mcpServer,

--- a/types/config.go
+++ b/types/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	Mode           Mode         `yaml:"mode" json:"mode"`
 	CDPEndpoint    string       `yaml:"cdpEndpoint" json:"cdpEndpoint"`
 	ServerName     string       `yaml:"serverName" json:"serverName"`
-	ServerVersion  string       `yaml:"-" json:"-"`
 	BrowserBinPath string       `yaml:"browserBinPath" json:"browserBinPath"`
 	Headless       bool         `yaml:"headless" json:"headless"`
 	BrowserTempDir string       `yaml:"browserTempDir" json:"browserTempDir"`


### PR DESCRIPTION
The Version field in the config struct was not used. And it was being passed as the version for the MCP server. If the version is an empty string some MCP clients with refuse to load the server, for example Cursor throws:

```
[error] -rod: Failed to reload client: MCP error -32000: Connection closed
[error] -rod: No server info found
```